### PR TITLE
Fix token parsing

### DIFF
--- a/app/auth/biz/service/decode_token.go
+++ b/app/auth/biz/service/decode_token.go
@@ -21,6 +21,9 @@ func GetUserIDFromToken(token string) (int32, error) {
 
 	// 把 token 分为好几段，其中第二段（parts[1]）是 payload
 	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return 0, fmt.Errorf("token 格式非法")
+	}
 	// 按照 base64 解码
 	payloadString, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {

--- a/app/order/biz/service/show_order_detail_test.go
+++ b/app/order/biz/service/show_order_detail_test.go
@@ -2,8 +2,8 @@ package service
 
 import (
 	"context"
-	"testing"
 	order "github.com/BeroKiTeer/MyGoMall/common/kitex_gen/order"
+	"testing"
 )
 
 func TestShowOrderDetail_Run(t *testing.T) {


### PR DESCRIPTION
## Summary
- handle invalid JWT tokens in `GetUserIDFromToken`
- gofmt autogenerated test file

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684aeb8dbca08323aabb2eb738b51772